### PR TITLE
fix(build): disable centos8 packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,13 +125,15 @@ try {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/dsm/${serie}/dsm-package.sh centos7"
       }
-    },
+    }
+/*
     'centos8': {
       node {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/dsm/${serie}/dsm-package.sh centos8"
       }
     }
+*/
     if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
       error('Package stage failure.')
     }


### PR DESCRIPTION
disable centos8 packaging due to centos8 eol (temporary)

